### PR TITLE
Updated Go build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,53 @@
 # versatus-go
 
+## Overview
+
 This package contains various structures and helper functions for building smart contracts for the Versatus network using Go.
 
 The `cmd/contract/main.go` file contains an example.
 
 Note that none of the inputs and outputs have been fully defined yet, and will change. Very soon.
+
+## Installing Toolchain
+
+In order to run this example on the Versatus network, it needs to be compiled to Web Assembly with WASI support. This is most-easily done using the TinyGo embedded Go compiler, but other options may work as long as there is a `_start` symbol and the module is statically linked.
+
+Installing TinyGo may be as simple as an `apt install tinygo` on many Linux distributions, or using something like `brew tap tinygo-org/tools && brew install tinygo` on MacOS, or by otherwise installing one of the releases from the [TinyGo Releases Page](https://github.com/tinygo-org/tinygo/releases).
+
+## Creating a Contract
+
+In order to build a smart contract for the Versatus network, simply include the `versatus-go/contract` package:
+
+```go
+import "github.com/versatus/versatus-go/contract"
+```
+
+The `contract` object will then allow you to parse the contract input (received on stdin) to Go data structures, and to write the result on stdout. For example:
+
+```go
+_, inputs := contract.ParseInput()
+```
+
+and:
+
+```go
+var outputs contract.ComputeOutputs
+_ = contract.SendOutput(outputs)
+```
+
+## Compiling a Contract
+
+Simply use the TinyGo compiler command instead of the standard Go compiler command, and specify the target as WASI:
+
+```
+tinygo build --target=wasi \
+    -scheduler=none -gc=conservative \
+    -o contract.wasm ./...
+```
+
+This should result in a `contract.wasm` file that is the Web Assembly smart contract.
+
+## Deploying a Contract to the Versatus Network
+
+TBA
+

--- a/sample-contract-input.json
+++ b/sample-contract-input.json
@@ -1,0 +1,21 @@
+{
+    "version": 1,
+    "accountInfo": {
+	"accountAddress": "contract_wallet_id",
+	"accountBalance": 65535
+    },
+    "protocolInput": {
+	"version": 1,
+	"blockHeight": 31415972,
+	"blockTime": 1694152781
+    },
+    "applicationInput": {
+	"contractFn": "splitEvenly",
+	"amount": 100,
+	"recipients": [
+	    "wallet_id_1",
+	    "wallet_id_2",
+	    "wallet_id_3"
+	]
+    }
+}

--- a/test.json
+++ b/test.json
@@ -1,1 +1,0 @@
-{ "version": 3, "txId": "bebb5089-b0e9-401e-b778-936bf58b36af", "lastBlockTime": 1692048126 }


### PR DESCRIPTION
Closes #3 and updates the sample JSON file. This will all likely change again as we further improve the inputs/outputs of the contracts, but this set of docs is probably the most comprehensive of any of the developer kits. @hathbanger and Rom, and @milideva , this probably serves as a reasonable template for the Javascript repo and the C and C++ repos, not only for the documentation side of things, but also as an example of using a language's in-built package system to hide a lot of the mechanics from the contract developer and make it as easy as possible. This will vary from language to language, but the intent is for the developer to `npm install` and include something, or to `git clone` and `#include` something and to quickly build their contract code.